### PR TITLE
依存関係の修正

### DIFF
--- a/src/adapters/controllers/user.controller.ts
+++ b/src/adapters/controllers/user.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get, Param } from '@nestjs/common';
-import { GetUserUseCase } from '../../use-cases/get-user.usecase';
-import { InMemoryUserRepository } from '../../infrastructure/repositories/in-memory-user.repository';
+import { GetUserUseCasePort } from '../../use-cases/ports/get-user-usecase.port';
+import { Inject } from '@nestjs/common';
 
 @Controller('users')
 export class UserController {
-  private readonly getUserUseCase = new GetUserUseCase(new InMemoryUserRepository());
+  constructor(
+    @Inject('GetUserUseCasePort') private readonly getUserUseCase: GetUserUseCasePort
+  ) {}
 
   @Get(':id')
   async getUser(@Param('id') id: string) {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,19 @@
 import { Module } from '@nestjs/common';
 import { UserController } from './adapters/controllers/user.controller';
+import { GetUserUseCase } from './use-cases/get-user.usecase';
+import { InMemoryUserRepository } from './infrastructure/repositories/in-memory-user.repository';
 
 @Module({
   controllers: [UserController],
+  providers: [
+    {
+      provide: 'GetUserUseCasePort',
+      useClass: GetUserUseCase,
+    },
+    {
+      provide: 'UserRepository',
+      useClass: InMemoryUserRepository,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/infrastructure/repositories/in-memory-user.repository.ts
+++ b/src/infrastructure/repositories/in-memory-user.repository.ts
@@ -1,6 +1,8 @@
+import { Injectable } from '@nestjs/common';
 import { UserRepositoryPort } from '../../domain/ports/user-repository.port';
 import { User } from '../../domain/entities/user.entity';
 
+@Injectable()
 export class InMemoryUserRepository implements UserRepositoryPort {
   private users = [new User(1, 'Alice'), new User(2, 'Bob')];
 

--- a/src/use-cases/get-user.usecase.ts
+++ b/src/use-cases/get-user.usecase.ts
@@ -1,9 +1,16 @@
+import { Injectable, Inject } from '@nestjs/common';
 import { UserRepositoryPort } from '../domain/ports/user-repository.port';
+import { User } from '../domain/entities/user.entity';
+import { GetUserUseCasePort } from './ports/get-user-usecase.port';
 
-export class GetUserUseCase {
-  constructor(private readonly userRepository: UserRepositoryPort) {}
 
-  async execute(id: number) {
+@Injectable()
+export class GetUserUseCase implements GetUserUseCasePort {
+  constructor(
+    @Inject('UserRepository') private readonly userRepository: UserRepositoryPort,
+  ) {}
+
+  async execute(id: number): Promise<User | null> {
     return this.userRepository.findUserById(id);
   }
 }

--- a/src/use-cases/ports/get-user-usecase.port.ts
+++ b/src/use-cases/ports/get-user-usecase.port.ts
@@ -1,0 +1,6 @@
+import { User } from '../../domain/entities/user.entity';
+
+export interface GetUserUseCasePort {
+    execute(id: number): Promise<User | null>;
+  }
+  


### PR DESCRIPTION
## Ticket
--

## Why
user.controller.ts が get-user.usecase.ts および in-memory-user.repository.ts に直接依存しており、依存性逆転の原則に違反していた。コントローラーはユースケースや具体実装には依存せず、ポートを通じて間接的に依存する構成が望ましい。

## What
・user.controller.ts からユースケースとリポジトリへの直接依存を解消
・get-user-usecase.port.ts を介してユースケースに依存するように変更
・DI 設定を見直し


## レビューポイント（任意）


## TODO


## その他（任意）


## 関連するPR（任意）
